### PR TITLE
Fixed a crash on iOS 13 devices

### DIFF
--- a/src/ios/PhotoLibraryService.swift
+++ b/src/ios/PhotoLibraryService.swift
@@ -311,9 +311,14 @@ final class PhotoLibraryService {
                         completion(nil, libraryItem)
                     }
                     else {
-                        let file_url:URL = info!["PHImageFileURLKey"] as! URL
-//                        let mime_type = self.mimeTypes[file_url.pathExtension.lowercased()]!
-                        completion(file_url.relativePath, libraryItem)
+                        if #available(iOS 13.0, *) {
+                            let file_url:NSString = (info!["PHImageFileUTIKey"] as? NSString)!
+                            completion(file_url as String, libraryItem)
+                        } else {
+                            let file_url:URL = info!["PHImageFileURLKey"] as! URL
+                            //let mime_type = self.mimeTypes[file_url.pathExtension.lowercased()]!
+                            completion(file_url.relativePath, libraryItem)
+                        }
                     }
                 }
             }


### PR DESCRIPTION
The key "PHImageFileURLKey" changed to "PHImageFileUTIKey".
This fix works on pre-iOS 13 devices, too.